### PR TITLE
Change max line length to 300

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -2,7 +2,7 @@
 bears = SpaceConsistencyBear, LineLengthBear
 files = **.html, **.yml, **.css, **.js, **.md
 ignore = **.min.css, **.min.js, _site/**
-max_line_length = 100
+max_line_length = 300
 use_spaces = True
 
 [html]


### PR DESCRIPTION
Max line length of 100 was seeming too short because certain urls easily exceeded that. This changes it to 300.