### PR TITLE
Fixes #199: Creating CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+#Contributing to [gci16.fossasia.org](http://gci16.fossasia.org/)
+
+## Code practices
+
+Please help us follow the best practice to make it easy for the reviewer as well as the contributor. 
+We want to focus on the code quality more than on managing pull request ethics. 
+
+ * Single commit per pull request, Name it to something meaningful such as `Adding <-your-name-> in students/mentors/blogs section`
+ * Reference the issue numbers in the commit message if it resolves an open issue. Follow the pattern ``` Fixes #<issue number> <commit message>```
+ * Provide the link to live `gh-pages` from your forked repository or relevant screenshot for easier review.
+ * The pull request will not get merged until and unless the commits are squashed. In case there are multiple commits on the PR, the commit author needs to squash them and not the maintainers cherrypicking and merging squashes.
+ * Pull Request older than 4 days with no response from the contributor shall be marked closed.
+ * Avoid duplicate PRs, if need be comment on the older PR with the PR number of the follow-up (new PR) and close the obsolete PR yourself.
+ 
+For further discussions & communications, please join us on FOSSASIA Slack at #gci channel, link: https://fossasia.slack.com/messages/gci.


### PR DESCRIPTION
Creating `CONTRIBUTING.md` to jot down coding practices and PR rules to ease out review process. 

cc: @niccokunzmann 