### PR TITLE
Split up responsibility and ability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,3 +23,23 @@ We want to focus on the code quality more than on managing pull request ethics.
 
 For further discussions & communications, please join us on FOSSASIA Slack at #gci channel, link: https://fossasia.slack.com/messages/gci.
 You can get an invite [here](http://fossasia-slack.herokuapp.com/).
+
+Also, we have a [team of maintainers](maintainers.md) to whom you can write with `@fossasia/gci16-maintainers`
+if your pull-request goes unnoticed. They may have time.
+
+## Git/Github Tutorials
+### Git: Introduction
+* [Git - the simple guide (awesome)](http://rogerdudler.github.io/git-guide/)
+* [An Intro to Git and GitHub for Beginners (Tutorial)](http://product.hubspot.com/blog/git-and-github-tutorial-for-beginners)
+
+### Github: Introduction
+* [An Intro to Git and GitHub for Beginners (Tutorial)](http://product.hubspot.com/blog/git-and-github-tutorial-for-beginners)
+* [Github Hello World](https://guides.github.com/activities/hello-world/)
+* [Changing a commit message](https://help.github.com/articles/changing-a-commit-message/)
+
+### Merge Commits
+* [How To Manually Fix Git Merge Conflicts (video)](https://www.youtube.com/watch?v=g8BRcB9NLp4)
+
+### Squash Commits
+* [Git Rebase (squash last commit)](https://www.youtube.com/watch?v=qh9KtjfjzCU)
+* [Squash Commits with Git](https://davidwalsh.name/squash-commits-git)

--- a/maintainers.md
+++ b/maintainers.md
@@ -11,7 +11,6 @@ Responsibilities of Maintainers
 - Be empathic: Better a bad PR with follow-up PRs than a closed PR and a rejected person.
 - Merge pull-requests.
 - Make sure people understand that you can not accept their GCI task.
-- Close old pull-requests, see [CONTRIBUTING.md](CONTRIBUTING.md)
 
 Not a responsibilty of a maintainer
 -----------------------------------
@@ -21,6 +20,12 @@ Not a responsibilty of a maintainer
   - Just do not merge them if you do not like them.
   - If they get old, they are closed.
   - Merge them and revert them to make the requester to a contributor in the future.
+
+Abilities of Maintainers
+------------------------
+
+- Close old pull-requests, see [CONTRIBUTING.md](CONTRIBUTING.md)
+- Remove merged branches.
 
 Further Reading
 ---------------


### PR DESCRIPTION
Problem: Just adding what maintainers can do to their responsibility may
overload them.

Solution: Responsibility and can-do abilities are divided. and ordered
by importance.