### PR TITLE
Resolves #235 Added editor config file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig is a file which defines behaviour for most text editors
+# I have added this so that there wont be any EOF problems or trailing
+# white space errors to ensure better experience for contributors.
+# Made with love for FOSSASIA
+
+# Defines that this is the top-most EditorConfig file.
+root = true
+
+# A newline ending every file and also trim the trailing white spaces.
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
I have added a robust solution that will remove trailing white spaces
and add a new line at the end of the file. This file is used by most
editors... @niccokunzmann what would you say.

Just to ensure you from the docs that,

> When opening a file, EditorConfig plugins look for a file named .editorconfig in the directory of the opened file and in every parent directory. A search for .editorconfig files will stop if the root filepath is reached or an EditorConfig file with root=true is found.

So this would do it.