### PR TITLE
Adding additional information for Jigyasa Grover in mentors

### DIFF
--- a/_data/mentors.yml
+++ b/_data/mentors.yml
@@ -34,6 +34,10 @@
   image: jgrover.jpg
   twitter: jigyasa_grover
   facebook: jigyasa.grover.14
+  github: jig08
+  blog: https://jigyasagrover.wordpress.com/
+  lat: 28.644800
+  lng: 77.216721
 
 - name: Phu Nguyen
   github: nghoangphu


### PR DESCRIPTION
Adding additional information for Jigyasa Grover in mentors including Github handle, blog link and location co-ordinates.