### PR TITLE
add note about randomizing the credentials' positions

### DIFF
--- a/_data/blogs.yml
+++ b/_data/blogs.yml
@@ -1,3 +1,5 @@
+# Please add your entries to a random position in the file.
+# This is to remove conflicts with other people adding entries.
 
 - name: Animesh Singh
   blog: http://blog.animeshsingh.in

--- a/_data/logos.yml
+++ b/_data/logos.yml
@@ -1,3 +1,6 @@
+# Please add your entries to a random position in the file.
+# This is to remove conflicts with other people adding entries.
+
 - author: Lee Care Gene
   img: Logo2.svg
 

--- a/_data/mentors.yml
+++ b/_data/mentors.yml
@@ -1,3 +1,6 @@
+# Please add your entries to a random position in the file.
+# This is to remove conflicts with other people adding entries.
+
 - name: Hong Phuc Dang
   github: hpdang
   image: hpdang.jpg

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,4 +1,6 @@
-# Please add new projects to bottom!
+# Please add your entries to a random position in the file.
+# This is to remove conflicts with other people adding entries.
+
 - name: Hangman
   owner: Jason Wong
   link: http://codethejason.github.io/gci2015/hangman/index.html

--- a/_data/slides.yml
+++ b/_data/slides.yml
@@ -1,3 +1,6 @@
+# Please add your entries to a random position in the file.
+# This is to remove conflicts with other people adding entries.
+
 - caption: FOSSASIA
   img: image_slider_crowd.jpg
   exp-1: We build a new era of Technology.

--- a/_data/students.yml
+++ b/_data/students.yml
@@ -1,4 +1,6 @@
-﻿# New members please add your credentials to the bottom of the file.
+﻿# New members please add your credentials to a random position in the file.
+# This is to remove conflicts with other people adding their credentials.
+
 - name: Animesh Singh
   github: animeshsinghweb
   facebook: f4.animeshsinghweb


### PR DESCRIPTION
When x members add their credentials to the bottom, in the worst case, we need to solve `(x-1)*x` merge conflicts, in the best case `x-1`.
I randomized the positions to add so they have less of a conflict. I guess that the merge conflicts can be estimated better by the [birthday paradox](https://en.wikipedia.org/wiki/Birthday_problem).

Current Problem: Several pull-request are open to add credentials.