### PR TITLE
removed page build failure

### DIFF
--- a/_data/students.yml
+++ b/_data/students.yml
@@ -295,6 +295,6 @@
 - name: Prabhdeep Singh
   github: prabhdeep29
   image: Prabhdeep.jpg
-  twitter: @singhprabh2929
+  twitter: singhprabh2929
   facebook: Prabhdeep Singh
   bio: 14, Programmer in every way


### PR DESCRIPTION
> 
> The page build failed with the following error:
> 
> There was a YAML syntax error on line 298 column 12 in `_data/students.yml`: `found character that cannot start any token while scanning for the next token`. For more information, see https://help.github.com/articles/page-build-failed-invalid-yaml-in-data-file.
> 
> For information on troubleshooting Jekyll see:
> 
>   https://help.github.com/articles/troubleshooting-jekyll-builds
> 
> If you have any questions you can contact us by replying to this email.
> 

Removed by removing the @.