### PR TITLE
Added bundler cache to speed up travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 services: docker
 rvm:
   - 2.3.3


### PR DESCRIPTION
Travis recently disabled automatic cache for bundler so let's enable it
for quicker builds. The results of travis cache will start to appear only after some builds because travis will only start caching now.