### PR TITLE
Fixes to Travis fail #884 from #456

### DIFF
--- a/index.html
+++ b/index.html
@@ -460,6 +460,6 @@
 &theme=default&scale=fit&skin=default&id=5843ed99c6db7" async></script>
 <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous" async></script>
 <script src="./javascripts/loklak-fetcher.js" async></script>
-<script src="./javascripts/tweet.js" async></script>
+<script src="./javascripts/tweet.js"></script>
 </body>
 </html>

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -331,12 +331,12 @@ $(function() {
           .append($('<a></a>').append(labels[i].name).attr("href", labels[i].html_url))
           .css("background", "#" + labels[i].color);
       categoryElement.append(titleButton);
-      for (var j = data.length - 1; j >= 0; j--) {
+      for (j = data.length - 1; j >= 0; j--) {
         for (var k = data[j].labels.length - 1; k >= 0; k--) {
           if (data[j].labels[k].name === labels[i].name) {
             // all hail .append()
             // build the issue element
-            issueElement = $('<div class="issue"></div>')
+            var issueElement = $('<div class="issue"></div>')
                 .append($("<span></span>").append(data[j].number))
                 .append($("<a></a>").attr("target", "_blank").attr('href', data[j].html_url).append(data[j].title))
                 .append($("<p>Opened by </p>").append($("<a></a>").append(data[j].user.login).attr("href", data[j].user.html_url).attr('target', '_blank')))

--- a/javascripts/tweet.js
+++ b/javascripts/tweet.js
@@ -36,7 +36,8 @@ function nextTweet() {
     interval();
     window.setTimeout(parseFunc, 560);
 }
-
+/**
+function was never used. remove comment tags only if itcauses errors.
 function lastTweet() {
     if (tweetNum > 0) {
         tweetNum -= 1;
@@ -44,7 +45,7 @@ function lastTweet() {
         window.setTimeout(parseFunc, 560);
     }
 }
-
+*/
 function parser(data) {
     var parsed = "";
     var tweet = data.statuses[tweetNum].text;


### PR DESCRIPTION
<!-- Safe Edit -->
- Updated tweet.js
   
`javascripts/tweet.js`
`|  14| ••••loklakFetcher.getTweets({},•datahandler);`
`|    | [NORMAL] JSHintBear:`
`|    | 'loklakFetcher' is not defined.`
> Resolved by removing the async attribute from the script tag of tweet.js on line 463 in index.html
   
   
`javascripts/tweet.js`
`|  40| function•lastTweet()•{`
`|    | [NORMAL] JSHintBear:`
`|    | 'lastTweet' is defined but never used.`
> Put the said definition within comment tags. Should be removed if the feature is required in the future. (Should add that somewhere for reference?)
   
   
   
- Updated main.js
   
`javascripts/main.js`
`| 334| ••••••for•(var•j•=•data.length•-•1;•j•>=•0;•j--)•{`
`|    | [NORMAL] JSHintBear:`
`|    | 'j' is already defined.`
   
> Removed var keyword on line 334 to resolve this.
   
   
`javascripts/main.js`
`| 339| ••••••••••••issueElement•=•$('<div•class="issue"></div>')`
`|    | [NORMAL] JSHintBear:`
`|    | 'issueElement' used out of scope.`
  
`javascripts/main.js`
`| 350| ••••••••••••categoryElement.append(issueElement);`
`|    | [NORMAL] JSHintBear:`
`|    | 'issueElement' used out of scope.`
  
> Redeclared issueElement on line 339 which solves this error.