### PR TITLE
Remove async option

### DIFF
--- a/index.html
+++ b/index.html
@@ -459,7 +459,7 @@
 &layout=responsive&input=www.flickr.com/photos/fossasia&sort=0&by=user
 &theme=default&scale=fit&skin=default&id=5843ed99c6db7" async></script>
 <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous" async></script>
-<script src="./javascripts/loklak-fetcher.js"></script>
-<script src="./javascripts/tweet.js"></script>
+<script src="./javascripts/loklak-fetcher.js" async></script>
+<script src="./javascripts/tweet.js" async></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -459,7 +459,7 @@
 &layout=responsive&input=www.flickr.com/photos/fossasia&sort=0&by=user
 &theme=default&scale=fit&skin=default&id=5843ed99c6db7" async></script>
 <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous" async></script>
-<script src="./javascripts/loklak-fetcher.js" async></script>
+<script src="./javascripts/loklak-fetcher.js"></script>
 <script src="./javascripts/tweet.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The async option makes tweet.js load before loklak-fetcher.js loads, so it can't fetch the tweets using the loklak-fetcher script.