### PR TITLE
Fixing #535

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,6 @@ GEM
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
     blankslate (2.1.2.4)
-    claide (1.0.1)
     classifier-reborn (2.0.4)
       fast-stemmer (~> 1.0)
     coffee-script (2.4.1)
@@ -19,22 +18,19 @@ GEM
     coffee-script-source (1.11.1)
     colorator (0.1)
     colored (1.2)
+    commander (4.4.1)
+      highline (~> 1.7.2)
     concurrent-ruby (1.0.2)
-    danger (0.3.0)
-      claide
-      colored
-      git (~> 1.2.9)
-      nap
-      octokit
     ethon (0.9.1)
       ffi (>= 1.3.0)
     execjs (2.7.0)
     faraday (0.10.0)
       multipart-post (>= 1.2, < 3)
     fast-stemmer (1.0.2)
+    fastimage (2.0.1)
+      addressable (~> 2)
     ffi (1.9.14)
     gemoji (2.1.0)
-    git (1.2.9.1)
     github-pages (28)
       RedCloth (= 4.2.9)
       jekyll (= 2.4.0)
@@ -50,6 +46,7 @@ GEM
       pygments.rb (= 0.6.0)
       rdiscount (= 2.1.7)
       redcarpet (= 3.1.2)
+    highline (1.7.8)
     html-pipeline (1.9.0)
       activesupport (>= 2)
       nokogiri (~> 1.4)
@@ -62,6 +59,7 @@ GEM
       parallel (~> 1.3)
       typhoeus (~> 0.7)
       yell (~> 2.0)
+    httpclient (2.8.3)
     i18n (0.7.0)
     jekyll (2.4.0)
       classifier-reborn (~> 2.0)
@@ -107,7 +105,6 @@ GEM
     mini_portile2 (2.1.0)
     minitest (5.10.0)
     multipart-post (2.0.0)
-    nap (1.1.0)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
     octokit (4.6.2)
@@ -115,6 +112,13 @@ GEM
     parallel (1.10.0)
     parslet (1.5.0)
       blankslate (~> 2.0)
+    percy-cli (1.2.7)
+      commander (~> 4.3)
+      percy-client (~> 1.4)
+      thread (~> 0.2)
+    percy-client (1.9.0)
+      faraday (>= 0.9)
+      httpclient (>= 2.6)
     posix-spawn (0.3.12)
     public_suffix (2.0.4)
     pygments.rb (0.6.0)
@@ -130,6 +134,7 @@ GEM
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
+    thread (0.2.2)
     thread_safe (0.3.5)
     toml (0.1.2)
       parslet (~> 1.5.0)
@@ -144,9 +149,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  danger
+  fastimage
   github-pages
   html-proofer
+  jekyll
+  percy-cli
 
 BUNDLED WITH
    1.13.6

--- a/index.html
+++ b/index.html
@@ -272,11 +272,11 @@
                             <div class="avatar">
                                 {% if blog.blog_img %}
                                 <a href="{{blog.article_link}}">
-                                    <img src="images/blogs/{{blog.blog_img}}" alt="{{blog.name}}">
+                                    <div class="img" style="background-image:url(images/blogs/{{blog.blog_img}});"></div>
                                 </a>
                                 {% else %}
                                 <a href="#">
-                                    <img src="images/blogs/default.jpg" alt="{{blog.name}}">
+                                    <div class="img" style="background-image:url(images/blogs/default.jpg);"></div>
                                 </a>
                                 {% endif %}
                                 <p>

--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -182,11 +182,13 @@
 .blogs-sec .blogs-wrapper {
     background: #00bfa5;
 }
-.blogs-sec img {
+.blogs-sec .img {
     width:500px;
     height: 300px;
+    background-size: cover;
+    background-position: center;
 }
-.blogs-sec img:hover {
+.blogs-sec .img:hover {
     opacity: 0.8;
     cursor: pointer;
 }


### PR DESCRIPTION
<!-- Safe edit -->Making blog avatars use `background-size: cover` to avoid squashing images.
[Live demo](https://witus13.github.io/gci16.fossasia.org#blogs)

BTW: I haven't manually changed Gemfile.lock, idk why is it here, I only run a few commands based on what I found in .travis.yml to serve the page locally.