### PR TITLE
Close previous mentor's info in map

### DIFF
--- a/index.html
+++ b/index.html
@@ -754,20 +754,26 @@
             }]
       });
       var marker;
+      var infowindow = null;
       {% for mentor in site.data.mentors %}
           {% if mentor.lat %}
               marker = new google.maps.Marker({
                   position: new google.maps.LatLng({{mentor.lat}}, {{mentor.lng}}),
                   map: map
               });
-              var infowindow = new google.maps.InfoWindow();
+              
+              infowindow = null;
               var content = "<div><img class='img-rounded' src='images/mentors/{{mentor.image}}' width='240' height='240'><br/>{{mentor.name}}<br/></div>";
-              google.maps.event.addListener(marker, 'click', (function(marker, content, infowindow) {
+              google.maps.event.addListener(marker, 'click', (function(marker, content) {
                   return function() {
+                      if (infowindow) {
+                        infowindow.close();
+                      }
+                      infowindow = new google.maps.InfoWindow();
                       infowindow.setContent(content);
                       infowindow.open(map, marker);
                   };
-              })(marker, content, infowindow));
+              })(marker, content));
           {% endif %}
       {% endfor %}
     };

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -119,10 +119,6 @@ function onScroll() {
   $('a.menu-item').each(function() {
     var currLink = $(this);
     var refElement = $(currLink.attr("href"));
-    console.log("currLink: ");
-    console.log(currLink);
-    console.log("refElement: ");
-    console.log(refElement);
     if (typeof(refElement.position()) === 'undefined') {
       refElement = $("#projects");
     }


### PR DESCRIPTION
At http://gci16.fossasia.org, you click on a marker to see a mentor. Then if you want to see mentors at other markers, you may have to close the recent window. This is inconvenient.

Resolved at: https://hoangvanthien.github.io