### PR TITLE
Updated longitude and latitude for Nicco Kunzmann

### DIFF
--- a/_data/mentors.yml
+++ b/_data/mentors.yml
@@ -69,6 +69,8 @@
   image: niccokunzmann.jpg
   blog: niccokunzmann.github.io
   twitter: dannhaltohneson
+  lat: 52.386447999999994
+  lng: 13.097770899999999
 
 - name: Robby O'Connor
   github: robbyoconnor


### PR DESCRIPTION
The geo-locator showed the information: https://gci16.fossasia.org/geo/