### PR TITLE
Added --trace to see more debug output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@
     "bundle install"
   ],
   "script": [
-    "bundle exec jekyll build",
+    "bundle exec jekyll build --trace",
     "percy snapshot _site/",
     "ruby ./scripts/ImgChecker/ImgChecker.rb",
     "docker run --volume=$(pwd):/app --workdir=/app coala/base coala -C"


### PR DESCRIPTION
When jekyll builds, the --trace option shows more debug output.