### PR TITLE
Use `coala --non-interactive` instead of `coala-ci`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,10 @@ script:
   - bundle exec jekyll build
   - percy snapshot _site/
   - ruby ./scripts/image_checker.rb
-  - docker run --volume=$(pwd):/app --workdir=/app coala/base:pre /bin/bash -c "coala --apply-patches --no-orig; coala-ci"
+  - >
+    docker run --volume=$(pwd):/app --workdir=/app coala/base:pre /bin/bash -c
+    "coala --apply-patches --no-orig;
+    coala --non-interactive"
   - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash ./scripts/coala_patch.sh; fi'
 branches:
   only:


### PR DESCRIPTION
coala-ci is deprecated and it'll be removed in the future. To prevent CI
from failing because of coala updates, it's a good idea to not use
deprecated binaries or scripts.

![wwww](https://my.mixtape.moe/blxwye.png)