### PR TITLE
Run danger only on Pull requests and not on merge commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.3.3
 install:
   - gem install danger
-  - danger --verbose
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then danger --verbose; fi'
   - bundle install
 script:
   - bundle exec jekyll build


### PR DESCRIPTION
Running danger only on Pull requests and not on merge commits saves us valuable time and why should danger run on merge commits, so I thought we could have this feature...

I would also ask your opinion whether we want to make ImgChecker script run on a merge commit?