### PR TITLE
Removed blog_image entry

### DIFF
--- a/_data/blogs.yml
+++ b/_data/blogs.yml
@@ -198,7 +198,6 @@
 
 - name: Prajwal K Patil
   blog: https://prajwalpatil.tech.blog/
-  blog_img: prajwal.jpg
   article: My Participation in Google Code-in
   article_link: https://prajwalpatil.tech.blog/2016/12/27/experience-in-google-code-in/
 


### PR DESCRIPTION
I removed the Blog_image entry by Prajwal Patil, as no image was found by that name in Blogs folder.
Due to this it was not able to use the default one.

I think the contributor wants to use the same image that he posted in Students Section, so other possible solution is to paste that image in Blogs folder, but that one was 240x240 px which will not look good in the Blogs card.

Previously
![screenshot from 2016-12-31 14-50-49](https://cloud.githubusercontent.com/assets/18071765/21576882/8d76433e-cf68-11e6-9a77-159b0bc1c4f4.png)

Now (using default image)
![screenshot from 2016-12-31 14-51-46](https://cloud.githubusercontent.com/assets/18071765/21576889/b2b11fe8-cf68-11e6-901f-2b191bd92aab.png)

