### PR TITLE
Travis-CI: Allow building any branch name (again)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
 branches:
   only:
     - gh-pages
-    - /^.$/  # Allows builds for any other branch name
+    - /./  # Allows builds for any other branch name
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
ee7a7502c included an unnecessary change that used an incorrect
regular expression, breaking bf322568.