### PR TITLE
Travis: Preserve coala's cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: ruby
-cache: bundler
+cache: 
+  bundler: true
+  directories:
+  - .coala-cache
 services: docker
 rvm:
   - 2.3.3
@@ -11,7 +14,7 @@ script:
   - bundle exec jekyll build
   - ruby ./scripts/image_checker.rb
   - >
-    docker run --volume=$(pwd):/app --workdir=/app coala/base:0.9 /bin/bash -c
+    docker run --volume=$(pwd)/.coala-cache:/root/.local/share/coala --volume=$(pwd):/app --workdir=/app coala/base:0.9 /bin/bash -c
     "coala --apply-patches --no-orig;
     coala --non-interactive"
   - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash ./scripts/coala_patch.sh; fi'


### PR DESCRIPTION
<!-- http -->
Thank you for your pull request! Please read and understand everything below

Please acknowledge that you have read and understood each of the following before submitting your pull request.

<!-- Ignore MarkdownBear -->
# _Do not_ delete any text other than where you are instructed.
<!-- Stop ignoring MarkdownBear -->

**Maintainers: If any of these are left unchecked, do not merge.**

**Students: If one of them is not applicable to you -- Please check it anyways. DO NOT REMOVE ANYTHING!**

**You may check them after opening your pull request.**

You may do so by changing each `[ ]` to `[x]` Please take note of the whitespace as it matters.

- [x] Read and understood (see CONTRIBUTING.md)
- [x] Included a live link or preview screenshot
- [x] Images are `240 x 240` [w x h]
- [x] Resolved merge conflicts
- [x] Included a description of my change below

# Things done in this Pull Request

coala's cache are saved on $XDG_DATA_HOME/coala to speed up CI, we can
create a volume for that and preseve it's contents with Travis'
directory caching feature.

Closes https://github.com/fossasia/gci16.fossasia.org/issues/603